### PR TITLE
Fix LICENSE information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Peter Rupprecht, Stephan Gerhard
+Copyright (c) 2017 Friedrich Miescher Institute for Biomedical Research
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
For work done at the FMI, the copyright holder is the FMI.

(This doesn't affect your authorship, but has to be stated correctly in the license information, as I suppose this is not your private project.)